### PR TITLE
Update Pearl Street details

### DIFF
--- a/src/boulder-guide.erb
+++ b/src/boulder-guide.erb
@@ -43,7 +43,7 @@ activity_places = [
 	{href: 'http://www.boulderteahouse.com/', inner_html: 'Dushanbe Teahouse'},
 	{href: 'http://www.bcfm.org/', inner_html: 'Boulder Farmers Market'},
 	{href: 'https://jdsjoyrides.com/', inner_html: 'JD\'s Joyrides - eBike Tours'},
-	{href: 'https://www.southpearlstreet.com/', inner_html: 'Pear Street'},
+	{href: 'https://www.colorado.com/articles/pearl-street-mall-beloved-boulder-attraction', inner_html: 'Pearl Street'},
 	{href: 'https://streetwisearts.org/walking-tours/', inner_html: 'Streetwise Boulder Mural Walking Tour'},
 ]
 %>


### PR DESCRIPTION
## Summary

- Updated `Pear` to `Pearl`
- Updated website as it's for [Denver's Pearl Street](https://www.southpearlstreet.com/contact/)