### PR TITLE
Fix ability to copy paste address

### DIFF
--- a/src/_partials/_location.erb
+++ b/src/_partials/_location.erb
@@ -26,7 +26,7 @@
     </div>
     <div class="container">
         <div class="flex flex-col md:flex-row gap-[20px]">
-            <div class="w-full md:w-1/2 wow fadeInUp" data-wow-delay=".1s" style="visibility: visible; animation-delay: 0.1s;">
+            <div class="w-full md:w-1/2 wow fadeInUp relative" data-wow-delay=".1s" style="visibility: visible; animation-delay: 0.1s;">
                 <a href="https://www.etown.org/" target="_blank">
                     <img src="https://www.etown.org/wp-content/uploads/2021/02/eTown_Hallpic.jpg" alt="Interior of eTown Hall performance venue" class="object-cover object-center">
                     <div class="opacity-0 hover:opacity-100 duration-300 absolute inset-10 pb-8 z-10 flex justify-start items-end text-xl text-white">Photo courtesy of eTown &mdash; &copy; 2023</div>
@@ -43,7 +43,7 @@
                     eTown Hall is home to the famous <a href="https://www.etown.org/" class="font-bold text-dark hover:text-primary" target="_blank">eTown radio show</a>, as well as eTown’s offices, recording studio, and performance space.
                 </p>
                 <address>
-                    1535 Spruce Street, Boulder, CO 80302.
+                    <a href="https://maps.app.goo.gl/kfzADmWxCBPXr3cf8" target="_blank">1535 Spruce Street, Boulder, CO 80302</a>
                 </address>
             </div>
         </div>


### PR DESCRIPTION
This hover over thing is position absolute and unbounded, so I can't highlight/copy the address because the invisible portion of the hover over thing is over the address. Adding relative to the wrapping div contains it.

While I'm at it, let's link to google maps and get rid of that punctuation.